### PR TITLE
do not install environment in roots home

### DIFF
--- a/snakemake/atacseq/Dockerfile
+++ b/snakemake/atacseq/Dockerfile
@@ -26,5 +26,5 @@ COPY ./scripts/plot-quals.py ./scripts/plot-quals.py
 
 # This is probably cheating a bit :)
 # instead of altering the entrypoint to active the environment!
-ENV PATH=/root/micromamba/envs/snakemake/bin:$PATH
+ENV PATH=/opt/micromamba/envs/snakemake/bin:$PATH
 WORKDIR /code

--- a/snakemake/atacseq/README.md
+++ b/snakemake/atacseq/README.md
@@ -57,7 +57,7 @@ $ docker run -it --entrypoint bash snakemake
 Activate the environment:
 
 ```bash
-$ micromamba shell init --shell=bash --prefix=~/micromamba
+$ micromamba shell init --shell=bash --prefix=/opt/micromamba
 $ source /root/.bashrc
 $ eval $(micromamba shell hook --shell=bash)
 $ micromamba activate snakemake

--- a/snakemake/atacseq/setup.sh
+++ b/snakemake/atacseq/setup.sh
@@ -6,5 +6,6 @@ set -eEu -o pipefail
 curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
 mv bin/micromamba /usr/local/bin && rmdir bin
 which micromamba
-micromamba create --prefix snakemake -f environment.yaml
-micromamba shell init --shell=bash --prefix=~/micromamba
+mkdir -p /opt/micromamba/envs
+micromamba create --prefix /opt/micromamba/envs/snakemake -f environment.yaml
+micromamba shell init --shell=bash --prefix=/opt/micromamba


### PR DESCRIPTION
Although the container has the root user to start and then we run commands as flux, it's not best practice to keep stuffs in roots home - the flux user (run by root) won't be able to access it.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>