### PR TITLE
add dask with scikitlearn

### DIFF
--- a/dask-scikit-learn/Dockerfile
+++ b/dask-scikit-learn/Dockerfile
@@ -1,0 +1,11 @@
+ARG tag=mamba
+FROM ghcr.io/rse-ops/flux-conda:${tag}
+
+ENV DEBIAN_FRONTEND=nonintercative
+RUN apt-get update && apt-get install -y tzdata && \
+    pip install scikit-learn numpy && \
+    # Install my branch of dask distributed with flux integration
+    pip install git+https://github.com/researchapps/dask-jobqueue.git@add/flux && \
+    pip install dask-ml && \
+    apt-get clean
+

--- a/dask-scikit-learn/uptodate.yaml
+++ b/dask-scikit-learn/uptodate.yaml
@@ -1,0 +1,7 @@
+dockerbuild:
+
+  build_args:
+    tag:
+      key: tag
+      versions:
+       - mamba


### PR DESCRIPTION
This image can be used in the operator to install this PR branch https://github.com/dask/dask-jobqueue/pull/605 and that way we can share the example without worrying about updating the way the base container is built.